### PR TITLE
Add counters to slack models and tests

### DIFF
--- a/src/feasibility-residual.jl
+++ b/src/feasibility-residual.jl
@@ -43,6 +43,8 @@ function FeasibilityResidual(nlp::AbstractNLPModel; name = "$(nlp.meta.name)-fea
   if !equality_constrained(nlp)
     if unconstrained(nlp)
       throw(ErrorException("Can't handle unconstrained problem"))
+    elseif nlp isa AbstractNLSModel
+      return FeasibilityResidual(SlackNLSModel(nlp), name = name)
     else
       return FeasibilityResidual(SlackModel(nlp), name = name)
     end

--- a/src/slack-model.jl
+++ b/src/slack-model.jl
@@ -47,6 +47,7 @@ The slack variables are implicitly ordered as `[s(low), s(upp), s(rng)]`, where
 mutable struct SlackModel <: AbstractNLPModel
   meta::NLPModelMeta
   model::AbstractNLPModel
+  counters::Counters
 end
 
 NLPModels.show_header(io::IO, nlp::SlackModel) =
@@ -64,6 +65,7 @@ mutable struct SlackNLSModel <: AbstractNLSModel
   meta::NLPModelMeta
   nls_meta::NLSMeta
   model::AbstractNLPModel
+  counters::NLSCounters
 end
 
 NLPModels.show_header(io::IO, nls::SlackNLSModel) =
@@ -113,7 +115,7 @@ function SlackModel(model::AbstractNLPModel; name = model.meta.name * "-slack")
 
   meta = slack_meta(model.meta, name = name)
 
-  snlp = SlackModel(meta, model)
+  snlp = SlackModel(meta, model, model.counters)
   finalizer(nlp -> finalize(nlp.model), snlp)
 
   return snlp
@@ -134,7 +136,7 @@ function SlackNLSModel(model::AbstractNLSModel; name = model.meta.name * "-slack
     nln = model.nls_meta.nln,
   )
 
-  snls = SlackNLSModel(meta, nls_meta, model)
+  snls = SlackNLSModel(meta, nls_meta, model, model.counters)
   finalizer(nls -> finalize(nls.model), snls)
 
   return snls

--- a/test/test_slack_model.jl
+++ b/test/test_slack_model.jl
@@ -104,6 +104,8 @@
     jtu = zeros(N)
     @test all(jtprod!(smodel, x, u, jtu) ≈ Jtu)
 
+    @test smodel.counters == smodel.model.counters
+
     reset!(smodel)
   end
 


### PR DESCRIPTION
Following issue #9 

There is a funny case where `FeasibilityResidual` call `SlackModel` and then the counters is a `NLSCounters`, which explains the `Union{Counters, NLSCounters}`.