### PR TITLE
Remove `AbstractNLPModel` from the structure

### DIFF
--- a/src/feasibility-residual.jl
+++ b/src/feasibility-residual.jl
@@ -25,11 +25,11 @@ The slack variables are created using SlackModel.
 If ``\\ell_i = u_i``, no slack variable is created.
 In particular, if there are only equality constrained of the form ``c(x) = 0``, the resulting NLS is simply ``\\min_x \\tfrac{1}{2}\\|c(x)\\|^2``.
 """
-mutable struct FeasibilityResidual{T, S} <: AbstractNLSModel{T, S}
+mutable struct FeasibilityResidual{T, S, M <: AbstractNLPModel{T, S}} <: AbstractNLSModel{T, S}
   meta::NLPModelMeta{T, S}
   nls_meta::NLSMeta{T, S}
   counters::NLSCounters
-  nlp::AbstractNLPModel{T, S}
+  nlp::M
 end
 
 function NLPModels.show_header(io::IO, nls::FeasibilityResidual)

--- a/src/quasi-newton.jl
+++ b/src/quasi-newton.jl
@@ -2,28 +2,28 @@ export QuasiNewtonModel, LBFGSModel, LSR1Model
 
 abstract type QuasiNewtonModel{T, S} <: AbstractNLPModel{T, S} end
 
-mutable struct LBFGSModel{T, S} <: QuasiNewtonModel{T, S}
+mutable struct LBFGSModel{T, S, M <: AbstractNLPModel{T, S}} <: QuasiNewtonModel{T, S}
   meta::NLPModelMeta{T, S}
-  model::AbstractNLPModel{T, S}
+  model::M
   op::LBFGSOperator
 end
 
-mutable struct LSR1Model{T, S} <: QuasiNewtonModel{T, S}
+mutable struct LSR1Model{T, S, M <: AbstractNLPModel{T, S}} <: QuasiNewtonModel{T, S}
   meta::NLPModelMeta{T, S}
-  model::AbstractNLPModel{T, S}
+  model::M
   op::LSR1Operator
 end
 
 "Construct a `LBFGSModel` from another type of model."
 function LBFGSModel(nlp::AbstractNLPModel{T, S}; kwargs...) where {T, S}
   op = LBFGSOperator(T, nlp.meta.nvar; kwargs...)
-  return LBFGSModel{T, S}(nlp.meta, nlp, op)
+  return LBFGSModel{T, S, typeof(nlp)}(nlp.meta, nlp, op)
 end
 
 "Construct a `LSR1Model` from another type of nlp."
 function LSR1Model(nlp::AbstractNLPModel{T, S}; kwargs...) where {T, S}
   op = LSR1Operator(T, nlp.meta.nvar; kwargs...)
-  return LSR1Model{T, S}(nlp.meta, nlp, op)
+  return LSR1Model{T, S, typeof(nlp)}(nlp.meta, nlp, op)
 end
 
 NLPModels.show_header(io::IO, nlp::QuasiNewtonModel) =

--- a/src/slack-model.jl
+++ b/src/slack-model.jl
@@ -44,9 +44,9 @@ The slack variables are implicitly ordered as `[s(low), s(upp), s(rng)]`, where
 ``c_L ≤ c(x) < ∞``, ``-∞ < c(x) ≤ c_U`` and
 ``c_L ≤ c(x) ≤ c_U``, respectively.
 """
-mutable struct SlackModel{T, S} <: AbstractNLPModel{T, S}
+mutable struct SlackModel{T, S, M <: AbstractNLPModel{T, S}} <: AbstractNLPModel{T, S}
   meta::NLPModelMeta{T, S}
-  model::AbstractNLPModel{T, S}
+  model::M
 end
 
 NLPModels.show_header(io::IO, nlp::SlackModel) =
@@ -60,10 +60,10 @@ end
 
 """Like `SlackModel`, this model converts inequalities into equalities and bounds.
 """
-mutable struct SlackNLSModel{T, S} <: AbstractNLSModel{T, S}
+mutable struct SlackNLSModel{T, S, M <: AbstractNLPModel{T, S}} <: AbstractNLSModel{T, S}
   meta::NLPModelMeta{T, S}
   nls_meta::NLSMeta{T, S}
-  model::AbstractNLPModel{T, S}
+  model::M
 end
 
 NLPModels.show_header(io::IO, nls::SlackNLSModel) =

--- a/test/nls/feasibility-residual.jl
+++ b/test/nls/feasibility-residual.jl
@@ -95,7 +95,7 @@
 
   @testset "Show" begin
     nls = FeasibilityResidual(SimpleNLSModel())
-    @test typeof(nls.nlp) == SlackNLSModel{Float64, Vector{Float64}}
+    @test typeof(nls.nlp) == SlackNLSModel{Float64, Vector{Float64}, SimpleNLSModel{Float64, Vector{Float64}}}
     io = IOBuffer()
     show(io, nls)
     showed = String(take!(io))


### PR DESCRIPTION
This was already done in `FeasibilityFormNLS`.