### PR TITLE
Add abstract meta

### DIFF
--- a/src/quasi-newton.jl
+++ b/src/quasi-newton.jl
@@ -2,14 +2,14 @@ export QuasiNewtonModel, LBFGSModel, LSR1Model
 
 abstract type QuasiNewtonModel{T, S} <: AbstractNLPModel{T, S} end
 
-mutable struct LBFGSModel{T, S, M <: AbstractNLPModel{T, S}} <: QuasiNewtonModel{T, S}
-  meta::NLPModelMeta{T, S}
+mutable struct LBFGSModel{T, S, M <: AbstractNLPModel{T, S}, Meta <: AbstractNLPModelMeta{T, S}} <: QuasiNewtonModel{T, S}
+  meta::Meta
   model::M
   op::LBFGSOperator
 end
 
-mutable struct LSR1Model{T, S, M <: AbstractNLPModel{T, S}} <: QuasiNewtonModel{T, S}
-  meta::NLPModelMeta{T, S}
+mutable struct LSR1Model{T, S, M <: AbstractNLPModel{T, S}, Meta <: AbstractNLPModelMeta{T, S}} <: QuasiNewtonModel{T, S}
+  meta::Meta
   model::M
   op::LSR1Operator
 end
@@ -17,13 +17,13 @@ end
 "Construct a `LBFGSModel` from another type of model."
 function LBFGSModel(nlp::AbstractNLPModel{T, S}; kwargs...) where {T, S}
   op = LBFGSOperator(T, nlp.meta.nvar; kwargs...)
-  return LBFGSModel{T, S, typeof(nlp)}(nlp.meta, nlp, op)
+  return LBFGSModel{T, S, typeof(nlp), typeof(nlp.meta)}(nlp.meta, nlp, op)
 end
 
 "Construct a `LSR1Model` from another type of nlp."
 function LSR1Model(nlp::AbstractNLPModel{T, S}; kwargs...) where {T, S}
   op = LSR1Operator(T, nlp.meta.nvar; kwargs...)
-  return LSR1Model{T, S, typeof(nlp)}(nlp.meta, nlp, op)
+  return LSR1Model{T, S, typeof(nlp), typeof(nlp.meta)}(nlp.meta, nlp, op)
 end
 
 NLPModels.show_header(io::IO, nlp::QuasiNewtonModel) =

--- a/src/slack-model.jl
+++ b/src/slack-model.jl
@@ -75,7 +75,7 @@ function Base.show(io::IO, nls::SlackNLSModel)
   show(io, nls.model.counters)
 end
 
-function slack_meta(meta::NLPModelMeta{T, S}; name = meta.name * "-slack") where {T, S}
+function slack_meta(meta::AbstractNLPModelMeta{T, S}; name = meta.name * "-slack") where {T, S}
   ns = meta.ncon - length(meta.jfix)
   jlow = meta.jlow
   jupp = meta.jupp

--- a/test/nlp/quasi-newton.jl
+++ b/test/nlp/quasi-newton.jl
@@ -6,9 +6,9 @@
     J(x) = [1.0 -2.0; -0.5x[1] -2.0x[2]]
 
     for (QNM, QNO) in [(LSR1Model, LSR1Operator), (LBFGSModel, LBFGSOperator)],
-      T in [Float64, Float32]
+      T in [Float64, Float32], M in [NLPModelMeta, SimpleNLPMeta]
 
-      nlp = QNM(SimpleNLPModel(T))
+      nlp = QNM(SimpleNLPModel(T, M))
       n = nlp.meta.nvar
       m = nlp.meta.ncon
 

--- a/test/nlp/slack-model.jl
+++ b/test/nlp/slack-model.jl
@@ -1,5 +1,5 @@
 @testset "SlackModel NLP tests" begin
-  @testset "API" for T in [Float64, Float32]
+  @testset "API" for T in [Float64, Float32], M in [NLPModelMeta, SimpleNLPMeta]
     f(x) = (x[1] - 2)^2 + (x[2] - 1)^2
     ∇f(x) = T[2 * (x[1] - 2); 2 * (x[2] - 1); 0]
     H(x) = T[2.0 0 0; 0 2.0 0; 0 0 0]
@@ -7,7 +7,7 @@
     J(x) = T[1.0 -2.0 0; -0.5x[1] -2.0x[2] -1]
     H(x, y) = H(x) + y[2] * T[-0.5 0 0; 0 -2.0 0; 0 0 0]
 
-    nlp = SlackModel(SimpleNLPModel(T))
+    nlp = SlackModel(SimpleNLPModel(T, M))
     n = nlp.meta.nvar
     m = nlp.meta.ncon
 

--- a/test/nls/feasibility-form-nls.jl
+++ b/test/nls/feasibility-form-nls.jl
@@ -183,8 +183,8 @@
     @test strip.(split(chomp(showed), "\n")) == strip.(split(chomp(expected), "\n"))
   end
 
-  @testset "FeasibilityFormNLS of a FeasibilityResidual" for T in [Float64, Float32]
-    nlp = SimpleNLPModel(T)
+  @testset "FeasibilityFormNLS of a FeasibilityResidual" for T in [Float64, Float32], M in [NLPModelMeta, SimpleNLPMeta]
+    nlp = SimpleNLPModel(T, M)
     snlp = SlackModel(nlp)
     nls = FeasibilityResidual(nlp)
     fnlp = FeasibilityFormNLS(nls)

--- a/test/nls/feasibility-residual.jl
+++ b/test/nls/feasibility-residual.jl
@@ -1,10 +1,10 @@
 @testset "FeasibilityResidual tests" begin
-  @testset "NLS API" for T in [Float64, Float32]
+  @testset "NLS API" for T in [Float64, Float32], M in [NLPModelMeta, SimpleNLPMeta]
     F(x) = T[x[1] - 2x[2] + 1; -x[1]^2 / 4 - x[2]^2 + 1 - x[3]]
     JF(x) = T[1.0 -2.0 0; -0.5x[1] -2.0x[2] -1]
     HF(x, w) = w[2] * diagm(0 => T[-0.5; -2.0; 0.0])
 
-    nls = FeasibilityResidual(SimpleNLPModel(T))
+    nls = FeasibilityResidual(SimpleNLPModel(T, M))
     n = nls.meta.nvar
     ne = nls_meta(nls).nequ
 
@@ -60,7 +60,7 @@
     @test grad(nls, x) ≈ JF(x)' * F(x) ≈ gx
   end
 
-  @testset "NLP API" for T in [Float64, Float32]
+  @testset "NLP API" for T in [Float64, Float32], M in [NLPModelMeta, SimpleNLPMeta]
     F(x) = T[x[1] - 2x[2] + 1; -x[1]^2 / 4 - x[2]^2 + 1 - x[3]]
     JF(x) = T[1.0 -2.0 0; -0.5x[1] -2.0x[2] -1]
     HF(x, w) = w[2] * diagm(0 => T[-0.5; -2.0; 0.0])
@@ -68,7 +68,7 @@
     ∇f(x) = JF(x)' * F(x)
     H(x) = JF(x)' * JF(x) + HF(x, F(x))
 
-    nls = FeasibilityResidual(SimpleNLPModel(T))
+    nls = FeasibilityResidual(SimpleNLPModel(T, M))
     n = nls.meta.nvar
 
     x = randn(T, n)


### PR DESCRIPTION
When the `NLPModels` use another `meta` there was an error. So, I added a parametric type for abstract meta.

For instance, if we add a `AmplNLPMeta` in `AmplNLReader.jl`, see discussion in [PR 115](https://github.com/JuliaSmoothOptimizers/AmplNLReader.jl/pull/115/files).