### PR TITLE
Fix ordering of slack variabels in `cons`

### DIFF
--- a/src/slack-model.jl
+++ b/src/slack-model.jl
@@ -228,14 +228,14 @@ function NLPModels.cons_lin!(nlp::SlackModels, x::AbstractVector, c::AbstractVec
   nlow, nupp, nrng = length(jlow), length(jupp), length(jrng)
   @views begin
     cons_lin!(nlp.model, x[1:n], c)
-    for j in jlow
-      c[j] -= x[n + j]
+    for (j, i) in zip(jlow, (n + 1):(n + nlow))
+      c[j] -= x[i]
     end
-    for j in jupp
-      c[j] -= x[n + j]
+    for (j, i) in zip(jupp, (n + nlow + 1):(n + nlow + nupp))
+      c[j] -= x[i]
     end
-    for j in jrng
-      c[j] -= x[n + j]
+    for (j, i) in zip(jrng, (n + nlow + nupp + 1):(n + nlow + nupp + nrng))
+      c[j] -= x[i]
     end
   end
   return c
@@ -250,14 +250,14 @@ function NLPModels.cons_nln!(nlp::SlackModels, x::AbstractVector, c::AbstractVec
   nlow, nupp, nrng = length(jlow), length(jupp), length(jrng)
   @views begin
     cons_nln!(nlp.model, x[1:n], c)
-    for j in jlow
-      c[j] -= x[n + j]
+    for (j, i) in zip(jlow, (n + 1):(n + nlow))
+      c[j] -= x[i]
     end
-    for j in jupp
-      c[j] -= x[n + j]
+    for (j, i) in zip(jupp, (n + nlow + 1):(n + nlow + nupp))
+      c[j] -= x[i]
     end
-    for j in jrng
-      c[j] -= x[n + j]
+    for (j, i) in zip(jrng, (n + nlow + nupp + 1):(n + nlow + nupp + nrng))
+      c[j] -= x[i]
     end
   end
   return c


### PR DESCRIPTION
I introduced a bug in #48 . The ordering of slack variables matters. Here is a minimum working example illustrating the issue.
```
using ADNLPModels, NLPModels, NLPModelsModifiers
nlp = ADNLPModel(x -> sum(x), ones(2), x -> [x[1]^2; x[2]*x[1]], [-Inf, 1.0], [1.0, Inf])
function NLPModels.cons_nln!(::ADNLPModel, x, c)
  c .= [x[1]^2; x[2]*x[1]]
end
function NLPModels.jac_nln_structure!(::ADNLPModel, rows, cols)
  rows .= [1, 1, 2, 2]
  cols .= [1, 2, 1, 2]
  return rows, cols
end
function NLPModels.jac_nln_coord!(::ADNLPModel, x, vals)
  vals .= [2*x[1], 0.0, x[2], x[1]]
  return vals
end
function NLPModels.jprod_nln!(::ADNLPModel, x, v, jv)
  jv .= [2*x[1] * v[1], x[2] * v[1] + x[1] * v[2]]
  return jv
end
x0 = [1., 2.]
snlp = SlackModel(nlp)
s0 = [1., 2., 0.5, 4.]
#=
The slack variables are implicitly ordered as `[s(low), s(upp), s(rng)]`, where
`low`, `upp` and `rng` represent the indices of the constraints of the form
``c_L ≤ c(x) < ∞``, ``-∞ < c(x) ≤ c_U`` and
``c_L ≤ c(x) ≤ c_U``, respectively.
=#
@show nlp.meta.jlow == [2]
@show nlp.meta.jupp == [1]
@show nlp.meta.jrng == []
# So the constraint becomes: x[1]^2 + x[4] ; x[2] * x[1] + x[3]
@show cons_nln(snlp, s0) == [s0[1]^2 - s0[4] ; s0[2] * s0[1] - s0[3]]
```