### PR TITLE
Version 0.6.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NLPModelsModifiers"
 uuid = "e01155f1-5c6f-4375-a9d8-616dd036575f"
-version = "0.5.1"
+version = "0.6.0"
 
 [deps]
 FastClosures = "9aa1b823-49e4-5ca5-8b0f-3971ec8bab6a"


### PR DESCRIPTION
New breaking release implementing the linear API. I checked a couple of the breaking packages:
- NLPModelsTest: https://github.com/JuliaSmoothOptimizers/NLPModelsTest.jl/blob/consistency-lin/src/nlp/consistency.jl
- ADNLPModels https://github.com/JuliaSmoothOptimizers/ADNLPModels.jl/tree/add-linearAPI (even so, we will probably need to think about an improved version)
- LLSModels https://github.com/JuliaSmoothOptimizers/LLSModels.jl/tree/add-linearAPI