### PR TITLE
Fix bug in SlackModel

### DIFF
--- a/src/slack-model.jl
+++ b/src/slack-model.jl
@@ -5,7 +5,7 @@ export SlackModel, SlackNLSModel
 
 Return the relative indices of the set of indices `jl` within the set of indices `ind`.
 """
-get_slack_ind(jl, ind) = filter(x -> !isnothing(x), indexin(jl, ind))
+get_slack_ind(jl, ind) = convert(Vector{Int}, filter(x -> !isnothing(x), indexin(jl, ind)))
 
 """
     get_relative_indices(model)

--- a/src/slack-model.jl
+++ b/src/slack-model.jl
@@ -5,7 +5,7 @@ export SlackModel, SlackNLSModel
 
 Return the relative indices of the set of indices `jl` within the set of indices `ind`.
 """
-get_slack_ind(jl, ind) = findall(!isnothing, indexin(jl, ind))
+get_slack_ind(jl, ind) = filter(x -> !isnothing(x), indexin(jl, ind))
 
 """
     get_relative_indices(model)


### PR DESCRIPTION
The `findall` was reinterpreting the indices, for instance:
```
findall(!isnothing, [2; nothing]) # returns [1] !!
```
while `Int[2]` was expected.

In the new solution, we remove the `nothing` with `filter` and then convert to a `Vector{Int}`