### PR TITLE
Remove allocations in hprod for QN models

### DIFF
--- a/src/quasi-newton.jl
+++ b/src/quasi-newton.jl
@@ -124,7 +124,8 @@ function NLPModels.hprod!(
   Hv::AbstractVector;
   kwargs...,
 )
-  @views mul!(Hv[1:(nlp.meta.nvar)], nlp.op, v)
+  @lencheck nlp.meta.nvar Hv x v
+  mul!(Hv, nlp.op, v)
   return Hv
 end
 


### PR DESCRIPTION
Detected using the following script:
```
using Pkg
Pkg.activate(".")
using LinearAlgebra, NLPModels, NLPModelsModifiers
using NLPModelsTest # main version of NLPModelsTest

using NLPModelsTest

# Test Quasi-Newton:
# test LBFGSModel
map(
  nlp -> print_nlp_allocations(nlp, test_allocs_nlpmodels(nlp, linear_api = true, exclude = [hess])),
  map(x -> LBFGSModel(eval(Symbol(x))()), NLPModelsTest.nlp_problems),
)

# test LSR1Model
map(
  nlp -> print_nlp_allocations(nlp, test_allocs_nlpmodels(nlp, linear_api = true, exclude = [hess])),
  map(x -> LBFGSModel(eval(Symbol(x))()), NLPModelsTest.nlp_problems),
)
```