### PR TITLE
Save allocations in `cons!`

### DIFF
--- a/src/model-interaction.jl
+++ b/src/model-interaction.jl
@@ -35,7 +35,8 @@ function FeasibilityFormNLS(
   )
   nls_meta = NLSMeta{T, S}(nequ, nvar, x0 = x0, nnzj = nequ, nnzh = 0)
   tmp = similar(nls.meta.x0)
-  nlp = FeasibilityFormNLS{T, S, FeasibilityResidual{T, S}}(meta, nls_meta, nls, NLSCounters(), tmp)
+  tmpy = similar(meta.y0)
+  nlp = FeasibilityFormNLS{T, S, FeasibilityResidual{T, S}}(meta, nls_meta, nls, NLSCounters(), tmp, tmpy)
   finalizer(nlp -> finalize(nlp.internal), nlp)
 
   return nlp


### PR DESCRIPTION
The point is to avoid the combination of `views` of `nlp.meta.nln` and ranges. #77 