### PR TITLE
Add DiagonalQNModel and SpectralGradientModel

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,8 +12,8 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 FastClosures = "0.2.1, 0.3.0"
-LinearOperators = "2"
-NLPModels = "0.18, 0.19"
+LinearOperators = "2.5"
+NLPModels = "0.19"
 julia = "^1.6.0"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 FastClosures = "0.2.1, 0.3.0"
-LinearOperators = "2.5"
+LinearOperators = "^2.5.1"
 NLPModels = "0.19"
 julia = "^1.6.0"
 

--- a/src/quasi-newton.jl
+++ b/src/quasi-newton.jl
@@ -46,8 +46,11 @@ end
     DiagonalQNModel(nlp; d0 = fill!(S(undef, nlp.meta.nvar), 1.0), psb = false)
 
 Construct a `DiagonalQNModel` from another type of nlp.
-`d0` is the initial approximation of the diagonal of the Hessian.
-`psb = true` should be used to perform a PSB update (default: Andrei update). 
+`d0` is the initial approximation of the diagonal of the Hessian, and by default a vector of ones.
+`psb = true` should be used to perform a PSB update (default: Andrei update).
+See the
+[`DiagonalQN operator documentation`](https://juliasmoothoptimizers.github.io/LinearOperators.jl/stable/reference/#LinearOperators.DiagonalQN)
+for the choice of `psb` and more information about the used algorithms.
 """
 function DiagonalQNModel(
   nlp::AbstractNLPModel{T, S};
@@ -61,7 +64,11 @@ end
 """
     SpectralGradientModel(nlp; σ = 1.0)
 
-Construct a `SpectralGradientModel` from another type of nlp.
+Construct a `SpectralGradientModel` rhat approximates the Hessian as `σI` from another type of nlp.
+The keyword argument `σ` is the initial positive multiple of the identity.
+See the
+[`SpectralGradient operator documentation`](https://juliasmoothoptimizers.github.io/LinearOperators.jl/stable/reference/#LinearOperators.SpectralGradient)
+for more information about the used algorithms. 
 """
 function SpectralGradientModel(nlp::AbstractNLPModel{T, S}; σ::T = one(T)) where {T, S}
   op = SpectralGradient(σ, nlp.meta.nvar)

--- a/src/quasi-newton.jl
+++ b/src/quasi-newton.jl
@@ -2,44 +2,44 @@ export QuasiNewtonModel, LBFGSModel, LSR1Model, DiagonalQNModel, SpectralGradien
 
 abstract type QuasiNewtonModel{T, S} <: AbstractNLPModel{T, S} end
 
-mutable struct LBFGSModel{T, S, M <: AbstractNLPModel{T, S}, Meta <: AbstractNLPModelMeta{T, S}} <:
-               QuasiNewtonModel{T, S}
+mutable struct LBFGSModel{T, S, M <: AbstractNLPModel{T, S}, Meta <: AbstractNLPModelMeta{T, S},
+    Op <: LBFGSOperator{T}} <: QuasiNewtonModel{T, S}
   meta::Meta
   model::M
-  op::LBFGSOperator
+  op::Op
 end
 
-mutable struct LSR1Model{T, S, M <: AbstractNLPModel{T, S}, Meta <: AbstractNLPModelMeta{T, S}} <:
-               QuasiNewtonModel{T, S}
+mutable struct LSR1Model{T, S, M <: AbstractNLPModel{T, S}, Meta <: AbstractNLPModelMeta{T, S},
+    Op <: LSR1Operator{T}} <: QuasiNewtonModel{T, S}
   meta::Meta
   model::M
-  op::LSR1Operator
+  op::Op
 end
 
-mutable struct DiagonalQNModel{T, S, M <: AbstractNLPModel{T, S}, Meta <: AbstractNLPModelMeta{T, S}} <:
-               QuasiNewtonModel{T, S}
+mutable struct DiagonalQNModel{T, S, M <: AbstractNLPModel{T, S}, Meta <: AbstractNLPModelMeta{T, S},
+    Op <: DiagonalQN{T}} <: QuasiNewtonModel{T, S}
   meta::Meta
   model::M
-  op::DiagonalQN
+  op::Op
 end
 
-mutable struct SpectralGradientModel{T, S, M <: AbstractNLPModel{T, S}, Meta <: AbstractNLPModelMeta{T, S}} <:
-               QuasiNewtonModel{T, S}
+mutable struct SpectralGradientModel{T, S, M <: AbstractNLPModel{T, S}, Meta <: AbstractNLPModelMeta{T, S},
+    Op <: SpectralGradient{T}} <: QuasiNewtonModel{T, S}
   meta::Meta
   model::M
-  op::SpectralGradient
+  op::Op
 end
 
 "Construct a `LBFGSModel` from another type of model."
 function LBFGSModel(nlp::AbstractNLPModel{T, S}; kwargs...) where {T, S}
   op = LBFGSOperator(T, nlp.meta.nvar; kwargs...)
-  return LBFGSModel{T, S, typeof(nlp), typeof(nlp.meta)}(nlp.meta, nlp, op)
+  return LBFGSModel{T, S, typeof(nlp), typeof(nlp.meta), typeof(op)}(nlp.meta, nlp, op)
 end
 
 "Construct a `LSR1Model` from another type of nlp."
 function LSR1Model(nlp::AbstractNLPModel{T, S}; kwargs...) where {T, S}
   op = LSR1Operator(T, nlp.meta.nvar; kwargs...)
-  return LSR1Model{T, S, typeof(nlp), typeof(nlp.meta)}(nlp.meta, nlp, op)
+  return LSR1Model{T, S, typeof(nlp), typeof(nlp.meta), typeof(op)}(nlp.meta, nlp, op)
 end
 
 """
@@ -58,7 +58,7 @@ function DiagonalQNModel(
   psb::Bool = false,
 ) where {T, S}
   op = DiagonalQN(d0, psb)
-  return DiagonalQNModel{T, S, typeof(nlp), typeof(nlp.meta)}(nlp.meta, nlp, op)
+  return DiagonalQNModel{T, S, typeof(nlp), typeof(nlp.meta), typeof(op)}(nlp.meta, nlp, op)
 end
 
 """
@@ -72,7 +72,7 @@ for more information about the used algorithms.
 """
 function SpectralGradientModel(nlp::AbstractNLPModel{T, S}; σ::T = one(T)) where {T, S}
   op = SpectralGradient(σ, nlp.meta.nvar)
-  return SpectralGradientModel{T, S, typeof(nlp), typeof(nlp.meta)}(nlp.meta, nlp, op)
+  return SpectralGradientModel{T, S, typeof(nlp), typeof(nlp.meta), typeof(op)}(nlp.meta, nlp, op)
 end
 
 NLPModels.show_header(io::IO, nlp::QuasiNewtonModel) =

--- a/test/nlp/quasi-newton.jl
+++ b/test/nlp/quasi-newton.jl
@@ -9,7 +9,12 @@
     Jlin(x) = [1.0 -2.0]
     Jnln(x) = [-0.5x[1] -2.0x[2]]
 
-    for (QNM, QNO) in [(LSR1Model, LSR1Operator), (LBFGSModel, LBFGSOperator)],
+    for (QNM, QNO) in [
+      (LSR1Model, LSR1Operator),
+      (LBFGSModel, LBFGSOperator),
+      (DiagonalQNModel, DiagonalQN),
+      (SpectralGradientModel, SpectralGradient),
+    ],
       T in [Float64, Float32],
       M in [NLPModelMeta, SimpleNLPMeta]
 
@@ -18,7 +23,13 @@
       m = nlp.meta.ncon
 
       s, y = randn(T, n), randn(T, n)
-      B = QNO(T, n)
+      if QNO == DiagonalQN
+        B = QNO(ones(T, n))
+      elseif QNO == SpectralGradient
+        B = QNO(one(T), n)
+      else
+        B = QNO(T, n)
+      end
       push!(B, s, y)
       push!(nlp, s, y)
       H(x) = B
@@ -115,69 +126,46 @@
       Hop = hess_op!(nlp, x, Hv)
       @test Hop * v ≈ H(x) * v
 
-      reset_data!(nlp)
-      Hop = hess_op!(nlp, x, Hv)
-      @test Hop * v == v
+      if QNO ∈ [LSR1Operator, LBFGSOperator]
+        # I am not sure reset! makes sense for the other QN operator since we have to give a value to initialize it
+        # we can add some default values in LinearOperators later if needed, but it is easier to simply update d / σ
+        reset_data!(nlp)
+        Hop = hess_op!(nlp, x, Hv)
+        @test Hop * v == v
+      end
     end
   end
 
   @testset "Show" begin
-    nlp = LSR1Model(SimpleNLPModel())
-    io = IOBuffer()
-    show(io, nlp)
-    showed = String(take!(io))
-    storage_type = typeof(nlp)
-    expected = """$storage_type - A QuasiNewtonModel
-    Problem name: Simple NLP Model
-     All variables: ████████████████████ 2      All constraints: ████████████████████ 2
-              free: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                 free: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
-             lower: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                lower: ██████████⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 1
-             upper: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                upper: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
-           low/upp: ████████████████████ 2              low/upp: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
-             fixed: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                fixed: ██████████⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 1
-            infeas: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0               infeas: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
-              nnzh: ( 33.33% sparsity)   2               linear: ██████████⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 1
-                                                      nonlinear: ██████████⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 1
-                                                           nnzj: (  0.00% sparsity)   4
+    for QNM ∈ [LSR1Model, LBFGSModel, DiagonalQNModel, SpectralGradientModel]
+      nlp = QNM(SimpleNLPModel())
+      io = IOBuffer()
+      show(io, nlp)
+      showed = String(take!(io))
+      storage_type = typeof(nlp)
+      expected = """$storage_type - A QuasiNewtonModel
+      Problem name: Simple NLP Model
+      All variables: ████████████████████ 2      All constraints: ████████████████████ 2
+                free: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                 free: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
+              lower: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                lower: ██████████⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 1
+              upper: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                upper: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
+            low/upp: ████████████████████ 2              low/upp: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
+              fixed: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                fixed: ██████████⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 1
+              infeas: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0               infeas: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
+                nnzh: ( 33.33% sparsity)   2               linear: ██████████⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 1
+                                                        nonlinear: ██████████⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 1
+                                                            nnzj: (  0.00% sparsity)   4
 
-    Counters:
-               obj: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                 grad: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                 cons: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
-          cons_lin: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0             cons_nln: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                 jcon: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
-             jgrad: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                  jac: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0              jac_lin: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
-           jac_nln: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                jprod: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0            jprod_lin: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
-         jprod_nln: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0               jtprod: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0           jtprod_lin: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
-        jtprod_nln: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                 hess: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                hprod: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
-             jhess: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0               jhprod: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0"""
+      Counters:
+                obj: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                 grad: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                 cons: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
+            cons_lin: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0             cons_nln: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                 jcon: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
+              jgrad: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                  jac: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0              jac_lin: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
+            jac_nln: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                jprod: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0            jprod_lin: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
+          jprod_nln: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0               jtprod: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0           jtprod_lin: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
+          jtprod_nln: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                 hess: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                hprod: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
+              jhess: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0               jhprod: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0"""
 
-    @test strip.(split(chomp(showed), "\n")) == strip.(split(chomp(expected), "\n"))
-
-    nlp = LBFGSModel(SimpleNLPModel())
-    io = IOBuffer()
-    show(io, nlp)
-    showed = String(take!(io))
-    storage_type = typeof(nlp)
-    expected = """$storage_type - A QuasiNewtonModel
-    Problem name: Simple NLP Model
-     All variables: ████████████████████ 2      All constraints: ████████████████████ 2
-              free: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                 free: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
-             lower: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                lower: ██████████⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 1
-             upper: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                upper: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
-           low/upp: ████████████████████ 2              low/upp: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
-             fixed: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                fixed: ██████████⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 1
-            infeas: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0               infeas: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
-              nnzh: ( 33.33% sparsity)   2               linear: ██████████⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 1
-                                                      nonlinear: ██████████⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 1
-                                                           nnzj: (  0.00% sparsity)   4
-
-    Counters:
-               obj: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                 grad: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                 cons: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
-          cons_lin: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0             cons_nln: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                 jcon: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
-             jgrad: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                  jac: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0              jac_lin: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
-           jac_nln: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                jprod: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0            jprod_lin: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
-         jprod_nln: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0               jtprod: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0           jtprod_lin: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
-        jtprod_nln: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                 hess: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                hprod: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
-             jhess: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0               jhprod: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0"""
-
-    @test strip.(split(chomp(showed), "\n")) == strip.(split(chomp(expected), "\n"))
+      @test strip.(split(chomp(showed), "\n")) == strip.(split(chomp(expected), "\n"))
+    end
   end
 end

--- a/test/nlp/quasi-newton.jl
+++ b/test/nlp/quasi-newton.jl
@@ -49,8 +49,7 @@
       @test grad(nlp, x) ≈ ∇f(x)
       @test hprod(nlp, x, v) ≈ H(x) * v
       @test neval_hprod(nlp.model) == 0
-      (QNM == LSR1Model) && (@test neval_hprod(nlp) == 2)
-      (QNM == LBFGSModel) && (@test neval_hprod(nlp) == 1)
+      (QNM == LSR1Model) ? (@test neval_hprod(nlp) == 2) : (@test neval_hprod(nlp) == 1)
       @test cons(nlp, x) ≈ c(x)
       @test jac(nlp, x) ≈ J(x)
       @test jprod(nlp, x, v) ≈ J(x) * v
@@ -126,13 +125,9 @@
       Hop = hess_op!(nlp, x, Hv)
       @test Hop * v ≈ H(x) * v
 
-      if QNO ∈ [LSR1Operator, LBFGSOperator]
-        # I am not sure reset! makes sense for the other QN operator since we have to give a value to initialize it
-        # we can add some default values in LinearOperators later if needed, but it is easier to simply update d / σ
-        reset_data!(nlp)
-        Hop = hess_op!(nlp, x, Hv)
-        @test Hop * v == v
-      end
+      reset_data!(nlp)
+      Hop = hess_op!(nlp, x, Hv)
+      @test Hop * v == v
     end
   end
 

--- a/test/test_qn_model.jl
+++ b/test/test_qn_model.jl
@@ -50,6 +50,10 @@ qn_model = LSR1Model(nlp)
 check_qn_model(qn_model)
 qn_model = LSR1Model(nlp, mem = 2)
 check_qn_model(qn_model)
+qn_model = DiagonalQNModel(nlp)
+check_qn_model(qn_model)
+qn_model = SpectralGradientModel(nlp)
+check_qn_model(qn_model)
 
 @testset "objgrad of a qnmodel" begin
   struct OnlyObjgradModel <: AbstractNLPModel


### PR DESCRIPTION
Add DiagonalQNModel and SpectralGradientModel based upon the operators in LinearOperators.

I dropped NLPModels 0.18 because there were failures when testing the package with the counters and the show functions (AmplNLReader tests fail because of this).