### PR TITLE
Track bug with Julia >= 1.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NLPModelsModifiers.jl
+# NLPModelsModifiers
 
 This package provides optimization models based on [NLPModels](https://github.com/JuliaSmoothOptimizers/NLPModels.jl).
 The API can be found on their [documentation page](https://juliasmoothoptimizers.github.io/NLPModels.jl/dev/api).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NLPModelsModifiers
+# NLPModelsModifiers.jl
 
 This package provides optimization models based on [NLPModels](https://github.com/JuliaSmoothOptimizers/NLPModels.jl).
 The API can be found on their [documentation page](https://juliasmoothoptimizers.github.io/NLPModels.jl/dev/api).

--- a/src/feasibility-residual.jl
+++ b/src/feasibility-residual.jl
@@ -48,7 +48,7 @@ function FeasibilityResidual(
   name = "$(nlp.meta.name)-feasres",
 ) where {T, S}
   if !equality_constrained(nlp)
-    if unconstrained(nlp)
+    if unconstrained(nlp) || bound_constrained(nlp)
       throw(ErrorException("Can't handle unconstrained problem"))
     elseif nlp isa AbstractNLSModel
       return FeasibilityResidual(SlackNLSModel(nlp), name = name)

--- a/test/allocs_test.jl
+++ b/test/allocs_test.jl
@@ -49,7 +49,7 @@ end
     ),
     map(
       x -> FeasibilityResidual(eval(Symbol(x))(), name = x * "feas"),
-      setdiff(problems, ["MGH01"]),
+      setdiff(problems, ["MGH01", "BNDROSENBROCK"]),
     ),
   )
   # jtprod! https://github.com/JuliaSmoothOptimizers/NLPModelsModifiers.jl/issues/77


### PR DESCRIPTION
```
Check allocations for model modifiers of NLS: Error During Test at NLPModelsModifiers.jl\test\allocs_test.jl:29
  Got exception outside of a @test
  StackOverflowError:
  Stacktrace:
    [1] SlackNLSModel(model::BNDROSENBROCK{Float64, Vector{Float64}}; name::String)
      @ NLPModelsModifiers NLPModelsModifiers.jl\src\slack-model.jl:167
    [2] SlackNLSModel
      @ NLPModelsModifiers.jl\src\slack-model.jl:167 [inlined]
    [3] FeasibilityResidual(nlp::BNDROSENBROCK{Float64, Vector{Float64}}; name::String) (repeats 8699 times)
      @ NLPModelsModifiers NLPModelsModifiers.jl\src\feasibility-residual.jl:54
    [4] (::var"#108#118")(x::String)
      @ Main NLPModelsModifiers.jl\test\allocs_test.jl:51
    [5] iterate
      @ .\generator.jl:47 [inlined]
    [6] collect_to!(dest::Vector{FeasibilityResidual{Float64, Vector{Float64}, SlackNLSModel{Float64, Vector{Float64}, LLS{Float64, Vector{Float64}}}}}, itr::Base.Generator{Vector{String}, var"#108#118"}, offs::Int64, st::Int64)  
      @ Base .\array.jl:840
    [7] collect_to_with_first!(dest::Vector{FeasibilityResidual{Float64, Vector{Float64}, SlackNLSModel{Float64, Vector{Float64}, LLS{Float64, Vector{Float64}}}}}, v1::FeasibilityResidual{Float64, Vector{Float64}, SlackNLSModel{Float64, Vector{Float64}, LLS{Float64, Vector{Float64}}}}, itr::Base.Generator{Vector{String}, var"#108#118"}, st::Int64)
      @ Base .\array.jl:818
    [8] _collect(c::Vector{String}, itr::Base.Generator{Vector{String}, var"#108#118"}, #unused#::Base.EltypeUnknown, isz::Base.HasShape{1})
      @ Base .\array.jl:812
    [9] collect_similar(cont::Vector{String}, itr::Base.Generator{Vector{String}, var"#108#118"})
      @ Base .\array.jl:711
   [10] map(f::Function, A::Vector{String})
      @ Base .\abstractarray.jl:3261
   [11] include(fname::String)
      @ Base.MainInclude .\client.jl:478
   [12] include(fname::String)
      @ Base.MainInclude .\client.jl:478
   [13] eval
      @ .\boot.jl:370 [inlined]
   [14] exec_options(opts::Base.JLOptions)
      @ Base .\client.jl:280
   [15] _start()
      @ Base .\client.jl:522
```