### PR TITLE
Bump version from 0.7.4 to 0.8.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NLPModelsModifiers"
 uuid = "e01155f1-5c6f-4375-a9d8-616dd036575f"
-version = "0.7.4"
+version = "0.8.0"
 
 [deps]
 FastClosures = "9aa1b823-49e4-5ca5-8b0f-3971ec8bab6a"


### PR DESCRIPTION
Technically, the new getters are breaking, but I don't expect anyone to have written custom quasi-Newton models. In addition, the major version of this package is still zero.